### PR TITLE
added code for creating <penrose> medatadata field and subfields

### DIFF
--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -4,7 +4,6 @@
  *
  */
 
-import { sub } from "engine/AutodiffFunctions";
 import { shapedefs } from "shapes/Shapes";
 import { Shape } from "types/shape";
 import { LabelCache, State } from "types/state";
@@ -186,40 +185,6 @@ export const RenderStatic = async (
   svg.setAttribute("version", "1.2");
   svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
   svg.setAttribute("viewBox", `0 0 ${canvas.width} ${canvas.height}`);
-  
-  // Create custom <penrose> tag to store metadata
-  const metadata = document.createElementNS("https://penrose.cs.cmu.edu/metadata", "penrose");
-  
-  // Create <version> tag for penrose version
-  const version = document.createElementNS("https://penrose.cs.cmu.edu/version", "version");
-  version.insertAdjacentText('afterbegin', 'penrose version here');
-  
-  // Create <variation> tag for variation string
-  const variation = document.createElementNS("https://penrose.cs.cmu.edu/version", "variation");
-  variation.insertAdjacentText('afterbegin', 'penrose variation code here');
-
-  // Create <sub> tag to store substance (.sub) code
-  const substance = document.createElementNS("https://penrose.cs.cmu.edu/substance", "sub");
-  substance.insertAdjacentText('afterbegin', '.sub code here');
-
-  // Create <sty> tag to store style (.sty) code
-  const style = document.createElementNS("https://penrose.cs.cmu.edu/style", "sty");
-  style.insertAdjacentText('afterbegin', '.sty code here');
-
-  // Create <dsl> tag to store .dsl code
-  const dsl = document.createElementNS("https://penrose.cs.cmu.edu/dsl", "dsl");
-  dsl.insertAdjacentText('afterbegin', '.dsl code here');
-
-  // Add these new tags under the <penrose> metadata tag
-  metadata.appendChild(version);
-  metadata.appendChild(variation);
-  metadata.appendChild(substance);
-  metadata.appendChild(style);
-  metadata.appendChild(dsl);
-
-  // Add the <penrose> metadata tag to the parent <svg> tag
-  svg.appendChild(metadata);
-  
   return Promise.all(
     computeShapes(varyingValues).map((shape) =>
       RenderShape({


### PR DESCRIPTION
# Description
Adds new metadata tags in the Penrose exported SVG, with default values filled in.

Related issue/PR: #1129 on penrose main repository

# Implementation strategy and design decisions

We followed the suggested implementation of this metadata storage that was posted in the discussion, which was
to create our own custom non-renderable tags for Penrose data. We believe this is a suitable approach because it enables us to layer more data inside these tags, rather than adding our code as values of attributes in the master SVG tag.

To implement this, we created our new elements with new XML namespaces, as to eliminate confusion for the origin of these tags.

# Examples with steps to reproduce them

**.dsl**
```
type Set
```

**.sub**
```
Set A
```

**`.sty`**
```
canvas {
    width=500
    height=500
}

forall Set x {
    x.icon = Circle {
        strokeWidth:5.0
    }
}
```

Using the above code, the following tag is a direct child of the outermost `<svg>` element in the exported SVG:

```
<penrose xmlns="http://www.w3.org/2000/svg">
  <version>penrose version here</version>
  <variation>penrose variation code here</variation>
  <sub>.sub code here</sub>
  <sty>.sty code here</sty>
  <dsl>.dsl code here</dsl>
</penrose>
```

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings
- [X] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Questions that require more discussion or to be addressed in future development:
- What is the preferred format for the namespaces? Do we care about them? Currently it's just `cs.cmu.edu/penrose/<tag name>`
